### PR TITLE
Correct version of babel-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/gpslab/gpslab-controller/issues"
   },
   "devDependencies": {
-    "babel-core": "^",
+    "babel-core": "^6.26.3",
     "babel-plugin-loop-optimizer": "^1.4.1",
     "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",


### PR DESCRIPTION
Correct version of `babel-core` in dependencies.